### PR TITLE
Add `output.ecmaVersion` to configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ MIGRATION: Upgrade to the latest node.js version available.
   - MIGRATION: Change signature
 - `experiments` added (see Experiments section above, since alpha.19)
 - `watchOptions.followSymlinks` added (since alpha.19)
+- `output.ecmaVersion` added (since alpha.23, defaults to `2015`)
 
 ## Changes to the Defaults
 


### PR DESCRIPTION
While working on https://github.com/symfony/webpack-encore/pull/645 I was wondering why we now had arrow functions in the outputed code :)

For now I only added a line to the configuration changes, but maybe it deserves more exposure since it could be considered a breaking change for people targeting IE11.