### PR TITLE
Fix casing typo in buildDependencies

### DIFF
--- a/guides/persistent-caching.md
+++ b/guides/persistent-caching.md
@@ -78,7 +78,7 @@ Another example: The build usually also depends on your configuration file.
 You could specify it this way:
 
 ``` js
-cache.builddependencies: {
+cache.buildDependencies: {
     config: [__filename]
 }
 ```


### PR DESCRIPTION
If you copy/paste this like me, you get a weird error that type must be "memory"