### PR TITLE
Explicitly mention new output.ecmaVersion default

### DIFF
--- a/MIGRATION GUIDE.md
+++ b/MIGRATION GUIDE.md
@@ -66,6 +66,10 @@ Update the following options to their new version:
 * `HashedModulesPlugin` -> `optimization.moduleIds: "hashed"`
 * `optimization.occurrenceOrder: true` -> `optimization: { chunkIds: "total-size", moduleIds: "size" }`
 
+## Disable ES2015 syntax in boilerplate code, if necessary
+
+By default, Webpack's boilerplate code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `output.ecmaVersion: 5` to revert to ES5 syntax.
+
 # Test webpack 5 compatibility
 
 Try to set the following options in your webpack 4 build and check if it still works correctly.

--- a/MIGRATION GUIDE.md
+++ b/MIGRATION GUIDE.md
@@ -68,7 +68,7 @@ Update the following options to their new version:
 
 ## Disable ES2015 syntax in boilerplate code, if necessary
 
-By default, Webpack's boilerplate code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `output.ecmaVersion: 5` to revert to ES5 syntax.
+By default, Webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `output.ecmaVersion: 5` to revert to ES5 syntax.
 
 # Test webpack 5 compatibility
 

--- a/MIGRATION GUIDE.md
+++ b/MIGRATION GUIDE.md
@@ -66,7 +66,7 @@ Update the following options to their new version:
 * `HashedModulesPlugin` -> `optimization.moduleIds: "hashed"`
 * `optimization.occurrenceOrder: true` -> `optimization: { chunkIds: "total-size", moduleIds: "size" }`
 
-## Disable ES2015 syntax in boilerplate code, if necessary
+## Disable ES2015 syntax in runtime code, if necessary
 
 By default, Webpack's runtime code uses ES2015 syntax to build smaller bundles. If your build targets environments that don't support this syntax (like IE11), you'll need to set `output.ecmaVersion: 5` to revert to ES5 syntax.
 


### PR DESCRIPTION
I'm in the process of migrating to v5 now and introducing ES6 syntax would output broken builds for our legacy users. It may be worth calling out the new `output.ecmaVersion` setting and it's default value explicitly in the migration guide.