### PR TITLE
Note changes to CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,3 +1326,5 @@ These dependencies are cheaper to process and webpack uses them when possible
 - add `Compilation.deleteAsset` to correctly delete an assets and non-shared related assets
 - expose `require("webpack-sources")` as `require("webpack").sources`
 - terser 5
+- The `--dev`, `-d`, `--prod`, and `-p` CLI flags were removed in [webpack-cli 4.x](https://github.com/webpack/webpack-cli/blob/master/CHANGELOG.md#400-beta9-2020-09-19)
+- The `--optimize-minimize` flag has been renamed to `--optimization-minimize`.


### PR DESCRIPTION
Are these fine here, or should we create a new section for CLI flags?

The `--dev`, `-d`, `--prod`, and `-p` flags technically belong to webpack-cli, so I'm not sure if they belong in this changelog. But still, people might run into this when migrating to webpack v5, since they'll update webpack-cli alongside it.

`--optimize-minimize` and `-p` are mentioned in this page: https://webpack.js.org/guides/production/#cli-alternatives so I assume they were active in v4. I'll update that doc too.

Related issue: https://github.com/webpack/webpack.js.org/issues/4465